### PR TITLE
Add MacPorts Portfile for cartesi-machine-emulator

### DIFF
--- a/dist/checksums.sh
+++ b/dist/checksums.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo $1
+echo rmd160 $(openssl dgst -rmd160 $1 | sed 's/^.*=//') \\
+echo sha256 $(openssl dgst -sha256 $1 | sed 's/^.*=//') \\
+stat -f "size   %z \\" $1

--- a/dist/macports/emulators/cartesi-machine-emulator/Portfile
+++ b/dist/macports/emulators/cartesi-machine-emulator/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            cartesi machine-emulator 0.18.2-test1 v
+github.tarball_from     archive
+name                    cartesi-machine-emulator
+categories              emulators
+license                 LGPL-3+
+platforms               darwin linux
+maintainers             @cartesi/emulator \
+                        @diegonehab
+description             The Cartesi Machine Emulator
+long_description    \
+    The Cartesi Machine Emulator is a feature-rich RISC-V emulator \
+    designed to support reproducible computations and fraud-proofs.
+patchfiles              add-generated-files.diff
+patch.pre_args          -p1
+patch_sites             https://github.com/${github.author}/${github.project}/releases/download/v${github.version}/
+checksums               ${distname}.tar.gz \
+                        rmd160 b715fc045215e7d4cba59eba920ad5c3dd7de1ba \
+                        sha256 9d5fb1139f0997f665a2130ab4a698080d7299d29d5e69494764510587ca9566 \
+                        size   1168705 \
+                        add-generated-files.diff \
+                        rmd160 3949ed54f5182893224e08df993d81821bd80221 \
+                        sha256 8f513f065e94e6ab969cd27186421e28db0091b3a563cd87280c3bb51671669e \
+                        size   518972
+depends_build-append    port:pkgconfig
+depends_lib-append      port:boost181 \
+                        port:lua54 \
+                        port:libslirp
+use_configure           no
+compiler.whitelist      macports-clang-16
+build.args-append       CC=${configure.cc} \
+                        CXX=${configure.cxx} \
+                        CPP=${configure.cpp}
+destroot.args-append    PREFIX=${prefix}
+build.args-append       PREFIX=${prefix}
+livecheck.type          none

--- a/dist/macports/emulators/cartesi-machine-linux/Portfile
+++ b/dist/macports/emulators/cartesi-machine-linux/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                cartesi-machine-linux
+categories          emulators
+version             0.20.0
+master_sites        https://github.com/cartesi/image-kernel/releases/download/v${version}/
+distname            linux-6.5.13-ctsi-1-v${version}
+extract.suffix      .bin
+maintainers         @cartesi/emulator \
+                    @diegonehab
+license             GPL-2
+supported_archs     noarch
+platforms           any
+description         Linux kernel for the Cartesi Machine Emulator
+long_description    \
+    The Linux kernel for the Cartesi Machine Emulator provides a default \
+    kernel that can be used to boot Linux in the emulator.
+homepage            https://github.com/cartesi/image-kernel
+checksums           rmd160 4a4f9215f199a86fa7a41b85b9142cdc09e3d624 \
+                    sha256 65dd100ff6204346ac2f50f772721358b5c1451450ceb39a154542ee27b4c947 \
+                    size   17529704
+use_configure       no
+build               {}
+destroot {
+    xinstall -d ${destroot}${prefix}/share/cartesi-machine/images
+    xinstall -W ${distpath} -m 0644 \
+                    ${distname}${extract.suffix} \
+                    ${destroot}${prefix}/share/cartesi-machine/images
+    ln -s ${distname}${extract.suffix} \
+                    ${destroot}${prefix}/share/cartesi-machine/images/linux${extract.suffix}
+}
+livecheck.type      none

--- a/dist/macports/emulators/cartesi-machine-rootfs/Portfile
+++ b/dist/macports/emulators/cartesi-machine-rootfs/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                cartesi-machine-rootfs
+categories          emulators
+version             0.16.2
+master_sites        https://github.com/cartesi/machine-emulator-tools/releases/download/v${version}-test1/
+distname            rootfs-tools-v${version}
+extract.suffix      .ext2
+maintainers         @cartesi/emulator \
+                    @diegonehab
+license             Apache-2
+supported_archs     noarch
+platforms           any
+description         Root filesystem for the Cartesi Machine Emulator
+long_description    \
+    The root filesystem for the Cartesi Machine Emulator provides a default \
+    filesystem that can be used to boot Linux in the emulator. \
+    \
+    This package installs what is, essentially, a Docker image converted to an \
+    ext2 filesystem image. The license shown for the package is what amounts to \
+    the license of the associated Dockerfile. The image, in contrast, includes a \
+    variety of packages, each with its own license. To see a list of packages in \
+    the ext2 filesystem image and their corresponding licenses, please see the \
+    /etc/LICENSES file that is inside the filesystem image itself.
+homepage            https://github.com/cartesi/machine-emulator-tools
+checksums           rmd160 8ec1e90a7020d22cd6270b9978ad35c4fbb6595f \
+                    sha256 bf82f702229cea00156a2306149f018dc5aab85f176846a1b06a4bee561f72a3 \
+                    size   104857600
+use_configure       no
+build               {}
+destroot {
+    xinstall -d ${destroot}${prefix}/share/cartesi-machine/images
+    xinstall -W ${distpath} -m 0644 \
+                    ${distname}${extract.suffix} \
+                    ${destroot}${prefix}/share/cartesi-machine/images
+    ln -s ${distname}${extract.suffix} \
+                    ${destroot}${prefix}/share/cartesi-machine/images/rootfs${extract.suffix}
+}
+livecheck.type      none

--- a/dist/macports/emulators/cartesi-machine/Portfile
+++ b/dist/macports/emulators/cartesi-machine/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                cartesi-machine
+categories          emulators
+version             0.20.0
+maintainers         @cartesi/emulator \
+                    @diegonehab
+license             Apache-2
+description         The Cartesi Machine
+long_description    \
+    This is a metaport. It installs the Cartesi Machine Emulator, \
+    a default root filesystem, and a default Linux kernel.
+homepage               https://github.com/cartesi/machine-emulator-sdk
+master_sites
+distfiles
+platforms           any
+supported_archs     noarch
+use_configure       no
+build               { }
+depends_lib         port:cartesi-machine-emulator \
+                    port:cartesi-machine-rootfs \
+                    port:cartesi-machine-linux
+destroot                    {
+    xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}
+    system "echo ${version} > ${destroot}${prefix}/share/doc/${name}/VERSION"
+}
+livecheck.type      none


### PR DESCRIPTION
This PR adds the first version of the proposed `cartesi-machine-emulator` Portfile for MacPorts.